### PR TITLE
update case sensitive javascript variable name

### DIFF
--- a/_sources/installing.txt
+++ b/_sources/installing.txt
@@ -44,7 +44,7 @@ Ultimately, you just need to do this:
     <!-- jQuery should already be available -->
     <script src="/static/js/literallycanvas.jquery.js"></script>
 
-and pass a value for the ``imageUrlPrefix`` parameter to
+and pass a value for the ``imageURLPrefix`` parameter to
 :js:func:`$.literallycanvas`.
 
 Write code
@@ -77,4 +77,4 @@ Finally, instantiate Literally Canvas:
 
 .. code-block:: javascript
 
-    $('.literally').literallycanvas({imageUrlPrefix: '/static/img'});
+    $('.literally').literallycanvas({imageURLPrefix: '/static/img'});

--- a/installing.html
+++ b/installing.html
@@ -96,7 +96,7 @@ internals.</p>
 <span class="nt">&lt;script </span><span class="na">src=</span><span class="s">&quot;/static/js/literallycanvas.jquery.js&quot;</span><span class="nt">&gt;&lt;/script&gt;</span>
 </pre></div>
 </div>
-<p>and pass a value for the <tt class="docutils literal"><span class="pre">imageUrlPrefix</span></tt> parameter to
+<p>and pass a value for the <tt class="docutils literal"><span class="pre">imageURLPrefix</span></tt> parameter to
 <a class="reference internal" href="api.html#_S_.literallycanvas" title="$.literallycanvas"><tt class="xref js js-func docutils literal"><span class="pre">$.literallycanvas()</span></tt></a>.</p>
 </div>
 <div class="section" id="write-code">
@@ -120,7 +120,7 @@ Otherwise your canvas will have a height of zero.</p>
 <p class="last">You should <strong>not</strong> set the size by styling <tt class="docutils literal"><span class="pre">&lt;canvas&gt;</span></tt>.</p>
 </div>
 <p>Finally, instantiate Literally Canvas:</p>
-<div class="highlight-javascript"><div class="highlight"><pre><span class="nx">$</span><span class="p">(</span><span class="s1">&#39;.literally&#39;</span><span class="p">).</span><span class="nx">literallycanvas</span><span class="p">({</span><span class="nx">imageUrlPrefix</span><span class="o">:</span> <span class="s1">&#39;/static/img&#39;</span><span class="p">});</span>
+<div class="highlight-javascript"><div class="highlight"><pre><span class="nx">$</span><span class="p">(</span><span class="s1">&#39;.literally&#39;</span><span class="p">).</span><span class="nx">literallycanvas</span><span class="p">({</span><span class="nx">imageURLPrefix</span><span class="o">:</span> <span class="s1">&#39;/static/img&#39;</span><span class="p">});</span>
 </pre></div>
 </div>
 </div>


### PR DESCRIPTION
Installation instructions refer to javascript variable "imageURLPrefix" as "imageUrlPrefix", this is rectified in the pull request.

Thank you.
